### PR TITLE
Provide build environment with latest zkLLVM and Boost 1.7.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# build to ghcr.io/nilfoundation/zkllvm-template:latest
+FROM ghcr.io/nilfoundation/build-base:1.76.0
+
+RUN DEBIAN_FRONTEND=noninteractive \
+    echo 'deb [trusted=yes]  http://deb.nil.foundation/ubuntu/ all main' >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get -y --no-install-recommends --no-install-suggests install \
+      build-essential \
+      cmake \
+      git \
+      zkllvm \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/zkllvm-template

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,48 @@
+# build to ghcr.io/nilfoundation/build-base:$BOOST_VERSION
+
+ARG BOOST_VERSION=1.76.0
+ARG BOOST_VERSION_UNDERSCORED=1_76_0
+ARG BOOST_SETUP_DIR=/opt/boost_${BOOST_VERSION_UNDERSCORED}
+ARG BOOST_BUILD_DIRECTORY=/tmp/boost_${BOOST_VERSION_UNDERSCORED}
+
+FROM ubuntu:22.04 as boost_builder
+RUN DEBIAN_FRONTEND=noninteractive \
+    set -xe \
+    && apt-get update \
+    && apt-get -y --no-install-recommends --no-install-suggests install \
+        autoconf \
+        automake \
+        build-essential \
+        wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# using global args with their default versions
+ARG BOOST_VERSION
+ARG BOOST_VERSION_UNDERSCORED
+ARG BOOST_SETUP_DIR
+ARG BOOST_BUILD_DIRECTORY
+
+WORKDIR /tmp
+RUN set -xe \
+    && wget -q --no-check-certificate \
+      https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORED}.tar.gz \
+    && mkdir ${BOOST_BUILD_DIRECTORY} \
+    && tar -xvf boost_${BOOST_VERSION_UNDERSCORED}.tar.gz \
+    && rm boost_${BOOST_VERSION_UNDERSCORED}.tar.gz
+
+WORKDIR ${BOOST_BUILD_DIRECTORY}
+RUN set -xe \
+    && sh ./bootstrap.sh --prefix=${BOOST_SETUP_DIR} \
+    && ./b2 --prefix=${BOOST_SETUP_DIR} \
+    && ./b2 install --prefix=${BOOST_SETUP_DIR}
+
+
+FROM ubuntu:22.04
+LABEL Name=build-base Version=1.76.0
+# using global args with their default versions
+ARG BOOST_SETUP_DIR
+
+COPY --from=boost_builder ${BOOST_SETUP_DIR} ${BOOST_SETUP_DIR}
+ENV BOOST_ROOT=${BOOST_SETUP_DIR}
+


### PR DESCRIPTION
* Provide build environment with latest zkLLVM and Boost 1.7.6 as
  a Docker image downloadable from
  `ghcr.io/nilfoundation/zkllvm-template:latest`.
  For now, this image is built and pushed manually.
  CI/CD pipelines will be introduced later.

  As a result of this change, users can do
  ```bash
  docker run -it --rm -v$(pwd):/opt/zkllvm-template \
    ghcr.io/nilfoundation/zkllvm-template:latest
  ```
  and work in a prepared environment.


* Prebuild an image with Boost, reducing image size by using
  multistage build. Developed by @color-typea.
  This image is built manually and available at
  `ghcr.io/nilfoundation/build-base:1.76.0`.

Building the base image:
```bash
docker build -t ghcr.io/nilfoundation/build-base:1.76.0 --file Dockerfile.base .
docker login ghcr.io
docker push ghcr.io/nilfoundation/build-base:1.76.0
```

Building the final image:
```bash
docker build -t ghcr.io/nilfoundation/zkllvm-template:latest .
docker login ghcr.io
docker push ghcr.io/nilfoundation/zkllvm-template:latest
```

Resolve nilfoundation/zkllvm#75