### PR TITLE
Two-stage dockerfile, separating building boost, and using it in zkllvm docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,52 @@
-FROM ubuntu:22.04
+ARG BOOST_VERSION=1.76.0
+ARG BOOST_VERSION_UNDERSCORED=1_76_0
+ARG BOOST_SETUP_DIR=/opt/boost_${BOOST_VERSION_UNDERSCORED}
+ARG BOOST_BUILD_DIRECTORY=/tmp/boost_${BOOST_VERSION_UNDERSCORED}
 
+FROM ubuntu:22.04 as boost_builder
 RUN DEBIAN_FRONTEND=noninteractive \
     set -xe \
-    && echo 'deb [trusted=yes]  http://deb.nil.foundation/ubuntu/ all main' >> /etc/apt/sources.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends --no-install-suggests \
-      zkllvm \
-      cmake \
-      build-essential \
-      wget \
+    && apt-get -y --no-install-recommends --no-install-suggests install \
+        autoconf \
+        automake \
+        build-essential \
+        wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# using global args with their default versions
+ARG BOOST_VERSION
+ARG BOOST_VERSION_UNDERSCORED
+ARG BOOST_SETUP_DIR
+ARG BOOST_BUILD_DIRECTORY
 
 WORKDIR /tmp
 RUN set -xe \
     && wget -q --no-check-certificate \
-      https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz \
-    && tar -xvf boost_1_76_0.tar.gz \
-    && rm boost_1_76_0.tar.gz
+      https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORED}.tar.gz \
+    && mkdir ${BOOST_BUILD_DIRECTORY} \
+    && tar -xvf boost_${BOOST_VERSION_UNDERSCORED}.tar.gz \
+    && rm boost_${BOOST_VERSION_UNDERSCORED}.tar.gz
 
-WORKDIR /tmp/boost_1_76_0
-
+WORKDIR ${BOOST_BUILD_DIRECTORY}
 RUN set -xe \
-    && sh ./bootstrap.sh \
-    && ./b2 \
-    && ./b2 install
+    && sh ./bootstrap.sh --prefix=${BOOST_SETUP_DIR} \
+    && ./b2 --prefix=${BOOST_SETUP_DIR} \
+    && ./b2 install --prefix=${BOOST_SETUP_DIR}
 
-WORKDIR /opt/zkllvm-template
+
+
+FROM ubuntu:22.04
+LABEL Name=zkllvm-dev Version=0.0.1
+# using global args with their default versions
+ARG BOOST_SETUP_DIR
+ARG WORKDIR=/opt/workdir
+
+RUN echo 'deb [trusted=yes]  http://deb.nil.foundation/ubuntu/ all main' >>/etc/apt/sources.list \
+    && apt update \
+    && apt install -y zkllvm cmake build-essential git \ 
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=boost_builder ${BOOST_SETUP_DIR} ${BOOST_SETUP_DIR}
+ENV BOOST_ROOT=${BOOST_SETUP_DIR}


### PR DESCRIPTION
The additional advantage of this approach is having a cleaner (and smaller) image for use in development - no boost source code and build artifacts are left in the final image.