### PR TITLE
Make circuits and assignment tables: CI implementation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: Test the development workflow
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+concurrency:
+  group: ${{
+    ( github.ref == 'refs/heads/master' &&
+    format('{0}/{1}', github.run_id, github.run_attempt) )
+    ||
+    format('{0}/{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+env:
+  SCRIPT_NAME: docker-run.sh
+
+jobs:
+  test-ll-workflow:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Run the workflow script
+        run: scripts/${{ env.SCRIPT_NAME }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,14 @@
-#---------------------------------------------------------------------------#
-# Copyright (c) 2018-2023 Mikhail Komarov <nemo@nil.foundation>
-#
-# Distributed under the Boost Software License, Version 1.0
-# See accompanying file LICENSE_1_0.txt or copy at
-# http://www.boost.org/LICENSE_1_0.txt
-#---------------------------------------------------------------------------#
-
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
-cmake_policy(SET CMP0028 NEW)
-cmake_policy(SET CMP0042 NEW)
-cmake_policy(SET CMP0048 NEW)
-cmake_policy(SET CMP0057 NEW)
-cmake_policy(SET CMP0077 NEW)
-
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake"
-     "${CMAKE_CURRENT_LIST_DIR}/cmake/modules/share/modules/cmake")
+     "${CMAKE_CURRENT_LIST_DIR}/cmake/modules/share/modules/cmake"
+     "/usr/share/zkllvm")
 
 include(CMConfig)
-include(CMDeploy)
 include(CMSetupVersion)
+include(CircuitCompile)
 
-cm_workspace(zkllvm)
+cm_workspace(crypto3)
 
 macro(cm_find_package NAME)
     if(NOT "${NAME}" MATCHES "^${CMAKE_WORKSPACE_NAME}_.*$" AND NOT "${NAME}" STREQUAL CM)
@@ -31,5 +18,9 @@ macro(cm_find_package NAME)
     endif()
 endmacro()
 
+cm_setup_version(VERSION 0.1.0 PREFIX ${CMAKE_WORKSPACE_NAME})
+
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/libs/crypto3")
+
+#Example directories
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/src")

--- a/scripts/build-circuit-ll.sh
+++ b/scripts/build-circuit-ll.sh
@@ -1,0 +1,31 @@
+#/usr/bin/env bash
+set -euxo pipefail
+
+# checking files that should be produced by the compiler
+check_file_exists() {
+  FILE1="${1}"
+  if [ ! -e "$FILE1" ]
+  then
+      echo "File $FILE1 was not created" >&2
+      exit 1
+  else
+      echo "File $FILE1 created successfully"
+  fi
+}
+
+rm -rf build && mkdir build && cd build
+cmake -DCIRCUIT_ASSEMBLY_OUTPUT=TRUE ..
+make template
+
+check_file_exists "./src/template.ll"
+
+assigner \
+  -b src/template.ll \
+  -i ../src/main.inp \
+  -c template.crct \
+  -t template.tbl \
+  -e pallas
+
+check_file_exists "./template.crct"
+check_file_exists "./template.tbl"
+

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -1,0 +1,19 @@
+#/usr/bin/env bash
+set -euxo pipefail
+
+# podman is a safer option for using on CI machines
+if ! command -v podman; then
+    DOCKER="docker"
+    DOCKER_OPTS=""
+else
+    DOCKER="podman"
+    DOCKER_OPTS='--detach-keys= --userns=keep-id'
+fi
+
+$DOCKER run $DOCKER_OPTS \
+  --rm \
+  --platform=linux/amd64 \
+  --user $(id -u ${USER}):$(id -g ${USER}) \
+  --volume $(pwd):/opt/zkllvm-template \
+  ghcr.io/nilfoundation/zkllvm-template:latest \
+  sh -c "bash ./scripts/build-circuit-ll.sh"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,68 +1,42 @@
-#---------------------------------------------------------------------------#
-# Copyright (c) 2018-2023 Mikhail Komarov <nemo@nil.foundation>
-#
-# Distributed under the Boost Software License, Version 1.0
-# See accompanying file LICENSE_1_0.txt or copy at
-# http://www.boost.org/LICENSE_1_0.txt
-#---------------------------------------------------------------------------#
+function(add_example example_target)
+    set(prefix ARG)
+    set(noValues "")
+    set(singleValues INPUT)
+    set(multiValues SOURCES)
+    cmake_parse_arguments(${prefix}
+                        "${noValues}"
+                        "${singleValues}"
+                        "${multiValues}"
+                        ${ARGN})
+    add_circuit(${example_target}
+                SOURCES ${ARG_SOURCES}
 
-cm_project(template WORKSPACE_NAME ${CMAKE_WORKSPACE_NAME} LANGUAGES C CXX)
+                LINK_LIBRARIES
+                crypto3::algebra
+                crypto3::block
+                crypto3::codec
+                crypto3::containers
+                crypto3::hash
+                crypto3::kdf
+                crypto3::mac
+                marshalling::core
+                marshalling::crypto3_algebra
+                marshalling::crypto3_multiprecision
+                marshalling::crypto3_zk
+                crypto3::math
+                crypto3::modes
+                crypto3::multiprecision
+                crypto3::passhash
+                crypto3::pbkdf
+                crypto3::threshold
+                crypto3::pkpad
+                crypto3::pubkey
+                crypto3::random
+                crypto3::stream
+                crypto3::vdf
+                crypto3::zk
 
-list(APPEND ${CURRENT_PROJECT_NAME}_PUBLIC_HEADERS)
+                ${Boost_LIBRARIES})
+endfunction()
 
-list(APPEND ${CURRENT_PROJECT_NAME}_UNGROUPED_SOURCES
-     main.cpp)
-
-list(APPEND ${CURRENT_PROJECT_NAME}_HEADERS
-     ${${CURRENT_PROJECT_NAME}_PUBLIC_HEADERS})
-
-list(APPEND ${CURRENT_PROJECT_NAME}_SOURCES
-     ${${CURRENT_PROJECT_NAME}_UNGROUPED_SOURCES})
-
-cm_setup_version(VERSION 0.1.0 PREFIX ${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME})
-
-add_library(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} OBJECT ${${CURRENT_PROJECT_NAME}_SOURCES})
-
-set_target_properties(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} PROPERTIES
-                      EXPORT_NAME ${CURRENT_PROJECT_NAME})
-
-target_link_libraries(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} PUBLIC
-                      crypto3::algebra
-                      crypto3::block
-                      crypto3::codec
-                      crypto3::containers
-                      crypto3::hash
-                      crypto3::kdf
-                      crypto3::mac
-                      marshalling::core
-                      marshalling::crypto3_algebra
-                      marshalling::crypto3_multiprecision
-                      marshalling::crypto3_zk
-                      crypto3::math
-                      crypto3::modes
-                      crypto3::multiprecision
-                      crypto3::passhash
-                      crypto3::pbkdf
-                      crypto3::threshold
-                      crypto3::pkpad
-                      crypto3::pubkey
-                      crypto3::random
-                      crypto3::stream
-                      crypto3::vdf
-                      crypto3::zk
-
-                      ${Boost_LIBRARIES})
-
-target_include_directories(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} INTERFACE
-                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                           $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
-
-                           ${Boost_INCLUDE_DIRS})
-
-cm_deploy(TARGETS ${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME}
-          INCLUDE include
-          NAMESPACE ${CMAKE_WORKSPACE_NAME}::)
-
-if(BUILD_TESTS)
-    add_subdirectory(test)
-endif()
+add_example(template SOURCES main.cpp INPUT main.inp)


### PR DESCRIPTION
# Make circuits and assignment tables: CI implementation

Changes in the tutorial will follow this PR (see #4)

### ci: build circuit and assignment table

Script `./scripts/build-circuit-ll.sh` runs in an environment with zkLLVM.
First, it builds the LLVM-IR form or circuit (`.ll`) with zkLLVM CLI.
Next, it builds the assignment table `.tbl` and circuit `.crct` with
assigner CLI.

Script `scripts/docker-run.sh` runs the first one in a container based
on a prebuilt image `ghcr.io/nilfoundation/zkllvm-template`,
that has all required dependencies, in particular, zkLLVM and Boost.
Script uses Podman when it is available, and Docker otherwise.

Using separate scripts (rather than `run` steps in CI) enables testing
the same workflow locally with a single command.

CI runs on default GitHub's `ubuntu-22.04` runners so that devs who fork
this repository would still have CI working in their forks.

Resolves #5

### Remove blueprint dependency from crypto3/marshalling/zk

Dependency on crypto3::blueprint in zk/marshalling was causing
the following error:

```
CMake Error at cmake/modules/share/modules/cmake/CMFuture.cmake:83 (_add_library):
  Target "zkllvm_circuit" links to target "crypto3::blueprint" but the target
  was not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
```

Resolves NilFoundation/zkllvm-template#22


### Crypto3: support optional Boost static library usage

Related to NilFoundation/zkllvm#85

### Revert commits related to #14

This reverts commits:
* https://github.com/NilFoundation/zkllvm-template/commit/dba71d68064bef368964d54cdee3a610babdb790
* https://github.com/NilFoundation/zkllvm-template/commit/fbf2d5f1caf7725ef073099686b5e64c0fb5d8ff
* https://github.com/NilFoundation/zkllvm-template/commit/08eb154c4e17b2ab4761434ececf4ad6a4304ca6

Resolves #24