### PR TITLE
ci: pin zkLLVM 0.0.58 and toolchain 0.0.31

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ concurrency:
     format('{0}/{1}', github.workflow, github.ref) }}
   cancel-in-progress: true
 
+env:
+  ZKLLVM_VERSION: 0.0.58
+  TOOLCHAIN_VERSION: 0.0.31
+
 jobs:
   test-zkllvm-workflow:
     runs-on: ubuntu-22.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # build to ghcr.io/nilfoundation/zkllvm-template:latest
 FROM ghcr.io/nilfoundation/build-base:1.76.0
 
+ARG ZKLLVM_VERSION=0.0.58
+
 RUN DEBIAN_FRONTEND=noninteractive \
     echo 'deb [trusted=yes]  http://deb.nil.foundation/ubuntu/ all main' >> /etc/apt/sources.list \
     && apt-get update \
@@ -8,7 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
       build-essential \
       cmake \
       git \
-      zkllvm \
+      zkllvm=${ZKLLVM_VERSION} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -37,7 +37,7 @@ compile() {
           --platform=linux/amd64 \
           --user $(id -u ${USER}):$(id -g ${USER}) \
           --volume $(pwd):/opt/zkllvm-template \
-          ghcr.io/nilfoundation/zkllvm-template:latest \
+          ghcr.io/nilfoundation/zkllvm-template:${ZKLLVM_VERSION} \
           sh -c "bash ./scripts/ci.sh compile"
         cd -
     else
@@ -62,7 +62,7 @@ run_assigner() {
           --platform=linux/amd64 \
           --user $(id -u ${USER}):$(id -g ${USER}) \
           --volume $(pwd):/opt/zkllvm-template \
-          ghcr.io/nilfoundation/zkllvm-template:latest \
+          ghcr.io/nilfoundation/zkllvm-template:${ZKLLVM_VERSION} \
           sh -c "bash ./scripts/ci.sh run_assigner"
         cd -
     else
@@ -90,7 +90,7 @@ build_statement() {
           --platform=linux/amd64 \
           --user $(id -u ${USER}):$(id -g ${USER}) \
           --volume $(pwd):/opt/zkllvm-template \
-          ghcr.io/nilfoundation/proof-market-toolchain:latest \
+          ghcr.io/nilfoundation/proof-market-toolchain:${TOOLCHAIN_VERSION}  \
           sh -c "bash /opt/zkllvm-template/scripts/ci.sh build_statement"
         cd -
     else
@@ -121,7 +121,7 @@ prove() {
           --volume $(pwd):/opt/zkllvm-template \
           --volume $(pwd)/.config:/root/.config \
           --volume $(pwd)/.config:/proof-market-toolchain/.config \
-          ghcr.io/nilfoundation/proof-market-toolchain:latest \
+          ghcr.io/nilfoundation/proof-market-toolchain:${TOOLCHAIN_VERSION} \
           sh -c "bash /opt/zkllvm-template/scripts/ci.sh prove"
         cd -
     else

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -119,6 +119,7 @@ prove() {
           --platform=linux/amd64 \
           --user $(id -u ${USER}):$(id -g ${USER}) \
           --volume $(pwd):/opt/zkllvm-template \
+          --volume $(pwd)/.config:/root/.config \
           --volume $(pwd)/.config:/proof-market-toolchain/.config \
           ghcr.io/nilfoundation/proof-market-toolchain:latest \
           sh -c "bash /opt/zkllvm-template/scripts/ci.sh prove"


### PR DESCRIPTION
# ci: pin zkLLVM 0.0.58 and toolchain 0.0.31

zkLLVM and Proof Market toolchain are based on a few common libraries,
which should be updated simultaneously in both tools.

Now CI and ci.sh script will use explicitly pinned versions of both tools
to show how to use them together.

Resolve https://github.com/NilFoundation/zkllvm-template/issues/30

##  ci: make extra directory with toolchain config

Sometimes `proof-producer` looks for the config at `/root/.config`.