### PR TITLE
ci.sh: print used image versions and set defaults

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -5,6 +5,14 @@ set -euxo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT="$SCRIPT_DIR/.."
 
+# Set image versions in the environment before running this script:
+# export ZKLLVM_VERSION=0.0.58
+# export TOOLCHAIN_VERSION=0.0.31
+
+# If unset, default values will be used:
+echo "using nilfoundation/zkllvm-template:${ZKLLVM_VERSION:=0.0.58}"
+echo "using nilfoundation/proof-market-toolchain:${TOOLCHAIN_VERSION:=0.0.31}"
+
 # podman is a safer option for using on CI machines
 if ! command -v podman; then
     DOCKER="docker"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -45,7 +45,7 @@ compile() {
         mkdir -p "$REPO_ROOT/build"
         cd "$REPO_ROOT/build"
         cmake -DCIRCUIT_ASSEMBLY_OUTPUT=TRUE ..
-        make template
+        VERBOSE=1 make template
         cd -
         check_file_exists "$REPO_ROOT/build/src/template.ll"
     fi


### PR DESCRIPTION
# ci.sh: print used image versions and set defaults

Set default versions for two used images:
```
nilfoundation/zkllvm-template
nilfoundation/proof-market-toolchain
```
These versions match ones in ./github/main.yml and should be updated
together.

With defaults, the script can be used without CI environment and
without setting env variables explicitly.

Resolves #34

# ci: run make template in verbose mode

In verbose mode, `make template` shows the exact command that is executed. It helps look and learn about the particular parameters used to compile circuits, in comparison with common x86 compiling.


```bash
cd /opt/zkllvm-template/build/src && \
clang -target assigner \
    -Xclang \
    -no-opaque-pointers \
    -Xclang \
    -fpreserve-vec3-type \
    -std=c++20 \
    -D__ZKLLVM__ \
    -I/opt/zkllvm-template/libs/crypto3/libs/algebra/include \
    -I/opt/zkllvm-template/build/include \
    -I/opt/boost_1_76_0/include \
    -I \
    -I/opt/zkllvm-template/libs/crypto3/libs/block/include \
    -I/opt/boost_1_76_0/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/codec/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/containers/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/hash/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/kdf/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/mac/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/marshalling/core/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/marshalling/algebra/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/marshalling/multiprecision/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/marshalling/zk/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/math/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/modes/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/multiprecision/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/passhash/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/pbkdf/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/pkmodes/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/pkpad/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/pubkey/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/random/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/stream/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/vdf/include \
    -I/opt/zkllvm-template/libs/crypto3/libs/zk/include \
    -emit-llvm \
    -O1 \
    -S \
    -o template.ll \
    /opt/zkllvm-template/src/main.cpp
```