### PR TITLE
readme: rewrite and update the workflows

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -7,7 +7,7 @@
 # Besides that, each command is checked in CI, just to make sure that
 # everything works for you when you run it yourself.
 
-set -euxo pipefail
+set -euo pipefail
 
 # define dirs so that we can run scripts from any directory without shifting filesystem paths
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )


### PR DESCRIPTION
# readme: rewrite and update the workflows

* New structure: dividing into the circuit developer and zk-app
  developer workflows.
* Rewrote the part with Proof Market almost completely.
* Removed the proof producer workflow. Will bring it back with
  instructions on deploying a self-hosted producer daemon with
  Docker.

https://github.com/NilFoundation/zkllvm-template/blob/21-proof-market-workflow/README.md

#  run.sh: run containers with a single command

Run containers with a single command:

./scripts/run.sh run_zkllvm
./scripts/run.sh run_proof_market_toolchain

Not checking this in CI because both commands open an interactive
console.

# run.sh: run in non-verbose mode by default

A fix of https://github.com/NilFoundation/zkllvm-template/commit/5e17eb77dd2cbf956ce6e523efbdf9e0fc1d11a4